### PR TITLE
[✨][Feat]#21: 로그인-회원가입 UI 구현 및 수정

### DIFF
--- a/src/components/BackSheet.tsx
+++ b/src/components/BackSheet.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react'
+
+type BackSheetProps = {
+  children: ReactNode
+  showHeader?: boolean
+  title?: string
+}
+
+const BackSheet = ({
+  children,
+  showHeader = false,
+  title = '',
+}: BackSheetProps) => {
+  return (
+    <div className='bg-gradient-to-b from-[#FFEBC0] to-white w-full min-h-screen py-16 px-32'>
+      <div className='bg-white rounded-xl shadow-lg w-full h-[calc(100vh-8rem)] flex flex-col p-8 relative'>
+        {/* 로고+타이틀 */}
+        {showHeader && (
+          <div className='absolute top-8 left-8'>
+            <h1 className='text-4xl font-extrabold text-orange_five hidden lg:block'>
+              MOZI
+            </h1>
+            {title && (
+              <h2 className='text-xl font-medium text-black pt-2'>{title}</h2>
+            )}
+          </div>
+        )}
+
+        {/* 컨텐츠 영역 */}
+        <div className='flex flex-1 items-center justify-center w-full'>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default BackSheet

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -8,6 +8,7 @@ type ButtonProps = {
   type?: 'button' | 'submit' // 버튼의 HTML 타입을 지정합니다. (기본값: 'button')
   baseButton?: boolean // 이 값이 true일 경우, 주황버튼 색상 스타일이 적용됩니다.
   size?: 's' | 'm' | 'l' // 버튼의 크기 ('s', 'm', 'l')를 설정합니다. (기본값: 'full')
+  loading?: boolean // 로딩 상태 여부
 }
 
 const Button = ({
@@ -17,6 +18,7 @@ const Button = ({
   type = 'button',
   baseButton = false,
   size,
+  loading = false,
 }: ButtonProps) => {
   // 모든 버튼에 공통으로 적용되는 기본 스타일들을 정의합니다.
   const baseClasses = `
@@ -47,7 +49,13 @@ const Button = ({
       // 기본 스타일, 색상 스타일, 너비 스타일, 그리고 사용자가 추가한 커스텀 스타일을 조합하여 적용합니다.
       className={`${baseClasses} ${colorClasses} ${buttonSizeClasses} ${className}`}
     >
-      {label}
+      {loading ? (
+        <div className='flex items-center justify-center space-x-2'>
+          <div className='w-5 h-5 border-2 border-t-white border-r-white border-b-transparent border-l-transparent rounded-full animate-spin'></div>
+        </div>
+      ) : (
+        label
+      )}
     </button>
   )
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -2,7 +2,7 @@
  * Button 컴포넌트가 받을 수 있는 props의 타입을 정의합니다.
  */
 type ButtonProps = {
-  label: string // 버튼에 표시될 텍스트입니다.
+  label: string | React.ReactNode // 버튼에 표시될 텍스트입니다.
   onClick?: () => void // 버튼 클릭 시 실행될 함수입니다.
   className?: string // Tailwind CSS 클래스를 추가하여 스타일을 커스텀할 수 있습니다.
   type?: 'button' | 'submit' // 버튼의 HTML 타입을 지정합니다. (기본값: 'button')

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -82,7 +82,7 @@ const Input = ({
       {label && (
         <label
           htmlFor={name}
-          className='font-medium text-sm sm:text-base text-black'
+          className='font-normal text-sm sm:text-base text-black'
         >
           {label}
         </label>
@@ -102,7 +102,7 @@ const Input = ({
             ${error || errorMessage ? 'focus:ring-red-500' : 'focus:ring-orange_three'}
             ${inputPaddingRightClass}
             placeholder-gray_one
-            placeholder:font-normal
+            placeholder:font-light
             ${inputSizeClasses[size]}
             ${className}`}
         />
@@ -116,7 +116,7 @@ const Input = ({
       {/* 에러 메시지 조건부 렌더링 */}
       {showError && (errorMessage || error) && (
         <p
-          className={`absolute -bottom-5 text-xs sm:text-sm mt-1 ${errorClassName}`}
+          className={`absolute -bottom-5 text-[10px] sm:text-[12px] mt-1 ${errorClassName}`}
         >
           {errorMessage || error}
         </p>

--- a/src/features/auth/LoginForm.tsx
+++ b/src/features/auth/LoginForm.tsx
@@ -1,13 +1,19 @@
 import Input from '@/components/Input'
 import Button from '@/components/Button'
 import { useLogin } from '@/hooks/useLogin'
+import { useNavigate } from 'react-router-dom'
 
 const LoginForm = () => {
   const { setEmail, setPassword, error, isLoading, handleLogin } = useLogin()
+  const navigate = useNavigate()
+
+  const handlePasswordReset = () => {
+    navigate('/password-reset')
+  }
 
   return (
-    <form onSubmit={handleLogin} className='flex flex-col space-y-4'>
-      <div className='space-y-6'>
+    <form onSubmit={handleLogin} className='flex flex-col w-full space-y-4'>
+      <div className='space-y-7'>
         <Input
           label='이메일'
           name='email'
@@ -26,13 +32,28 @@ const LoginForm = () => {
         />
         {error && <p className='text-red-500 text-sm'>{error}</p>}
       </div>
-      <div className='pt-2'>
-        <Button
-          label={isLoading ? '로그인 중...' : '로그인'}
-          type='submit'
-          baseButton
-        />
-      </div>
+
+      <button
+        type='button'
+        onClick={handlePasswordReset}
+        className='text-base text-orange_five hover:underline self-end mt-1 p-2'
+      >
+        비밀번호 찾기
+      </button>
+
+      <Button
+        type='submit'
+        baseButton
+        label={
+          isLoading ? (
+            <div className='flex items-center justify-center space-x-2'>
+              <div className='w-5 h-5 border-2 border-t-white border-r-white border-b-transparent border-l-transparent rounded-full animate-spin'></div>
+            </div>
+          ) : (
+            '로그인'
+          )
+        }
+      />
     </form>
   )
 }

--- a/src/features/auth/LoginForm.tsx
+++ b/src/features/auth/LoginForm.tsx
@@ -41,19 +41,7 @@ const LoginForm = () => {
         비밀번호 찾기
       </button>
 
-      <Button
-        type='submit'
-        baseButton
-        label={
-          isLoading ? (
-            <div className='flex items-center justify-center space-x-2'>
-              <div className='w-5 h-5 border-2 border-t-white border-r-white border-b-transparent border-l-transparent rounded-full animate-spin'></div>
-            </div>
-          ) : (
-            '로그인'
-          )
-        }
-      />
+      <Button type='submit' baseButton label='로그인' loading={isLoading} />
     </form>
   )
 }

--- a/src/features/auth/RegisterForm.tsx
+++ b/src/features/auth/RegisterForm.tsx
@@ -89,15 +89,8 @@ const RegisterForm = () => {
         <Button
           type='submit'
           baseButton
-          label={
-            isLoading ? (
-              <div className='flex items-center justify-center space-x-2'>
-                <div className='w-5 h-5 border-2 border-t-white border-r-white border-b-transparent border-l-transparent rounded-full animate-spin'></div>
-              </div>
-            ) : (
-              '회원가입 완료'
-            )
-          }
+          label='회원가입 완료'
+          loading={isLoading}
         />
       </div>
     </form>

--- a/src/features/auth/RegisterForm.tsx
+++ b/src/features/auth/RegisterForm.tsx
@@ -1,60 +1,24 @@
-import React, { useState } from 'react'
 import Input from '@/components/Input'
 import Button from '@/components/Button'
-import { UserApi } from '@/services/endpoints/user'
-import { useNavigate } from 'react-router-dom'
+import { useRegister } from '@/hooks/useRegister'
 
 const RegisterForm = () => {
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
-  const [passwordMatchError, setPasswordMatchError] = useState('')
-
-  const [register] = UserApi.useRegisterMutation()
-  const navigate = useNavigate()
-
-  // 🔹 공통: 비밀번호 일치 여부 검증
-  const validatePasswords = (pwd: string, confirmPwd: string) => {
-    if (pwd && confirmPwd && pwd !== confirmPwd) {
-      setPasswordMatchError('비밀번호가 일치하지 않습니다.')
-    } else {
-      setPasswordMatchError('')
-    }
-  }
-
-  // 비밀번호 입력 시
-  const handlePasswordChange = (value: string) => {
-    setPassword(value)
-    validatePasswords(value, confirmPassword)
-  }
-
-  // 비밀번호 재확인 입력 시
-  const handleConfirmPasswordChange = (value: string) => {
-    setConfirmPassword(value)
-    validatePasswords(password, value)
-  }
-
-  // 회원가입 요청
-  const handleSignup = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    // 불일치 시 API 요청 차단
-    if (password !== confirmPassword) return
-
-    try {
-      await register({
-        registerRequest: { email, password, agreed: true },
-      }).unwrap()
-      console.log('회원가입 성공!')
-      navigate('/login')
-    } catch (err) {
-      console.error('회원가입 실패:', err)
-    }
-  }
+  const {
+    email,
+    setEmail,
+    password,
+    confirmPassword,
+    passwordMatchError,
+    apiError,
+    isLoading,
+    handlePasswordChange,
+    handleConfirmPasswordChange,
+    handleSignup,
+  } = useRegister()
 
   return (
-    <form onSubmit={handleSignup} className='flex flex-col space-y-4'>
-      <div className='space-y-6'>
+    <form onSubmit={handleSignup} className='flex flex-col'>
+      <div className='space-y-7'>
         {/* 이메일 입력 + 인증 버튼 */}
         <div className='flex items-end space-x-2 w-full'>
           <Input
@@ -115,10 +79,26 @@ const RegisterForm = () => {
           errorMessage={passwordMatchError}
           showError={!!passwordMatchError}
         />
+
+        {/* API 에러 메시지 (추후 토스트메시지로 개발 예정) */}
+        {apiError && <p className='text-red-500 text-sm'>{apiError}</p>}
       </div>
 
-      <div className='pt-2'>
-        <Button label='회원가입 완료' type='submit' baseButton />
+      {/* 회원가입 버튼 */}
+      <div className='pt-10'>
+        <Button
+          type='submit'
+          baseButton
+          label={
+            isLoading ? (
+              <div className='flex items-center justify-center space-x-2'>
+                <div className='w-5 h-5 border-2 border-t-white border-r-white border-b-transparent border-l-transparent rounded-full animate-spin'></div>
+              </div>
+            ) : (
+              '회원가입 완료'
+            )
+          }
+        />
       </div>
     </form>
   )

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux'
 import { setCredentials } from '@/store/slices/authSlice'
 import { useNavigate } from 'react-router-dom'
 import type { AppDispatch } from '@/store/store'
+import { hasMessage } from '@/utils/errorGuards'
 
 /**
  * 커스텀 훅: 로그인 관련 상태와 함수 관리
@@ -55,9 +56,13 @@ export const useLogin = () => {
         // API는 성공했지만 데이터가 없는 경우
         setError('로그인에 실패했습니다.')
       }
-    } catch (err: any) {
-      // 로그인 실패 시 에러 메시지 처리
-      setError(err?.data?.message || '로그인 중 오류가 발생했습니다.')
+    } catch (err: unknown) {
+      let userMessage = '로그인에 실패했습니다.'
+
+      if (hasMessage(err)) {
+        userMessage = err.data.message
+      }
+      setError(userMessage)
       console.error('로그인 실패:', err)
     }
   }

--- a/src/hooks/useRegister.ts
+++ b/src/hooks/useRegister.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { UserApi } from '@/services/endpoints/user'
 import { useNavigate } from 'react-router-dom'
+import { hasMessage } from '@/utils/errorGuards'
 
 /**
  * 회원가입 로직을 관리하는 훅
@@ -80,11 +81,14 @@ export const useRegister = () => {
         registerRequest: { email, password, agreed: true },
       }).unwrap()
       navigate('/login') // 성공 시 로그인 페이지로 이동
-    } catch (err: any) {
-      // API 오류 메시지를 상태에 저장
-      setApiError(err?.data?.message || '회원가입에 실패했습니다.')
+    } catch (err: unknown) {
+      const userMessage = hasMessage(err)
+        ? err.data.message
+        : '회원가입에 실패했습니다.'
+      setApiError(userMessage)
+      console.error('회원가입 실패:', err)
     } finally {
-      setIsLoading(false) // 요청 완료
+      setIsLoading(false)
     }
   }
 

--- a/src/hooks/useRegister.ts
+++ b/src/hooks/useRegister.ts
@@ -1,0 +1,103 @@
+import { useState } from 'react'
+import { UserApi } from '@/services/endpoints/user'
+import { useNavigate } from 'react-router-dom'
+
+/**
+ * 회원가입 로직을 관리하는 훅
+ * - 입력값 상태 관리(email, password 등)
+ * - 비밀번호 일치 검증
+ * - API 요청 상태(isLoading) 관리
+ * - 에러 메시지 상태 관리(apiError)
+ */
+export const useRegister = () => {
+  // 입력값 상태
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+
+  // 비밀번호 불일치 오류 메시지
+  const [passwordMatchError, setPasswordMatchError] = useState('')
+
+  // API 요청 실패 시 표시할 에러 메시지
+  const [apiError, setApiError] = useState('')
+
+  // 회원가입 요청 중 상태
+  const [isLoading, setIsLoading] = useState(false)
+
+  // RTK Query의 register mutation
+  const [register] = UserApi.useRegisterMutation()
+  const navigate = useNavigate()
+
+  /**
+   * 비밀번호와 비밀번호 재확인이 일치하는지 검증
+   * @param pwd 비밀번호
+   * @param confirmPwd 비밀번호 재확인
+   */
+  const validatePasswords = (pwd: string, confirmPwd: string) => {
+    if (pwd && confirmPwd && pwd !== confirmPwd) {
+      setPasswordMatchError('비밀번호가 일치하지 않습니다.')
+    } else {
+      setPasswordMatchError('')
+    }
+  }
+
+  /**
+   * 비밀번호 입력값 변경 처리
+   * @param value 비밀번호
+   */
+  const handlePasswordChange = (value: string) => {
+    setPassword(value)
+    validatePasswords(value, confirmPassword)
+  }
+
+  /**
+   * 비밀번호 재확인 입력값 변경 처리
+   * @param value 비밀번호 재확인
+   */
+  const handleConfirmPasswordChange = (value: string) => {
+    setConfirmPassword(value)
+    validatePasswords(password, value)
+  }
+
+  /**
+   * 회원가입 폼 제출 처리
+   * - 비밀번호 일치 여부 확인
+   * - API 요청 수행
+   * - 요청 중 로딩 상태 관리
+   * - 요청 실패 시 에러 메시지 상태 업데이트
+   * - 요청 성공 시 로그인 페이지로 이동
+   */
+  const handleSignup = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+
+    // 비밀번호가 일치하지 않으면 요청 차단
+    if (password !== confirmPassword) return
+
+    try {
+      setApiError('') // 이전 에러 초기화
+      setIsLoading(true) // 요청 시작
+      await register({
+        registerRequest: { email, password, agreed: true },
+      }).unwrap()
+      navigate('/login') // 성공 시 로그인 페이지로 이동
+    } catch (err: any) {
+      // API 오류 메시지를 상태에 저장
+      setApiError(err?.data?.message || '회원가입에 실패했습니다.')
+    } finally {
+      setIsLoading(false) // 요청 완료
+    }
+  }
+
+  return {
+    email,
+    setEmail,
+    password,
+    confirmPassword,
+    passwordMatchError,
+    apiError,
+    isLoading,
+    handlePasswordChange,
+    handleConfirmPasswordChange,
+    handleSignup,
+  }
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,44 +1,50 @@
 import LoginForm from '@/features/auth/LoginForm'
 import Button from '@/components/Button'
-import { useSelector, useDispatch } from 'react-redux'
-import type { RootState, AppDispatch } from '@/store/store'
-import { logout } from '@/store/slices/authSlice'
+import { useSelector } from 'react-redux'
+import type { RootState } from '@/store/store'
 import { useNavigate } from 'react-router-dom'
+import BackSheet from '@/components/BackSheet'
+import { useEffect } from 'react'
 
 const Login = () => {
-  const { isLoggedIn, email } = useSelector((state: RootState) => state.auth)
-  const dispatch = useDispatch<AppDispatch>()
+  const { isLoggedIn } = useSelector((state: RootState) => state.auth)
   const navigate = useNavigate()
 
-  // 로그아웃 (추후 삭제 예정)
-  const handleLogout = () => {
-    dispatch(logout())
-    navigate('/login')
-  }
+  // 로그인 상태면 로그인 페이지 접근 차단
+  useEffect(() => {
+    if (isLoggedIn) {
+      navigate('/') // 홈으로 이동
+    }
+  }, [isLoggedIn, navigate])
 
   return (
-    <div className='flex flex-col items-center justify-center min-h-screen bg-white'>
-      <div className='w-full max-w-xl p-8 sm:p-10 space-y-6'>
-        <div className='flex flex-row items-center space-x-2'>
-          <h2 className='text-2xl font-bold text-black'>로그인</h2>
+    <BackSheet>
+      <div className='flex w-full h-full justify-center'>
+        {/* 왼쪽 영역 */}
+        <div className='w-full flex flex-col justify-center p-12 rounded-l-xl'>
+          <h1 className='text-4xl font-extrabold text-orange_five'>MOZI</h1>
+          <p className='text-lg font-medium mt-4'>
+            당신의 하루, 하나의 이모지로 전하세요 😊
+          </p>
+          <p className='text-md pt-24'>
+            아직 가입하지 않으셨나요? <br />
+            가입하고 오늘의 기분을 남겨보세요
+          </p>
+          <Button
+            label='회원가입'
+            type='button'
+            onClick={() => navigate('/register')}
+            className='mt-6'
+          />
         </div>
 
-        {isLoggedIn ? (
-          <>
-            <p className='mb-4'>{email}님, 이미 로그인 되어 있습니다.</p>
-            {/* 로그아웃 추후 삭제 예정  */}
-            <Button
-              label='로그아웃'
-              type='button'
-              baseButton
-              onClick={handleLogout}
-            />
-          </>
-        ) : (
+        <div className='absolute top-20 bottom-20 left-1/2 w-px bg-gray-300'></div>
+        {/* 오른쪽 로그인 영역 */}
+        <div className='w-full flex flex-col justify-center items-center p-12'>
           <LoginForm />
-        )}
+        </div>
       </div>
-    </div>
+    </BackSheet>
   )
 }
 

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,15 +1,16 @@
 import RegisterForm from '@/features/auth/RegisterForm'
+import BackSheet from '@/components/BackSheet'
 
 const Register = () => {
   return (
-    <div className='flex flex-col items-center justify-center min-h-screen bg-white'>
-      <div className='w-full max-w-xl p-8 sm:p-10 space-y-6'>
-        <div className='flex flex-row items-center space-x-2'>
-          <h2 className='text-2xl font-bold text-black'>회원가입</h2>
+    <BackSheet showHeader={true} title='회원가입'>
+      <div className='flex flex-col items-center justify-center w-full'>
+        <div className='w-full max-w-[448px]'>
+          <RegisterForm />
         </div>
-        <RegisterForm />
       </div>
-    </div>
+    </BackSheet>
   )
 }
+
 export default Register

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,6 @@
-import { createBrowserRouter } from 'react-router-dom'
+import { createBrowserRouter, Outlet, Navigate } from 'react-router-dom'
+import { useSelector } from 'react-redux'
+import { type RootState } from '@/store/store'
 
 import { RootLayout } from '@/layouts/RootLayout'
 import Home from '@/pages/Home'
@@ -6,16 +8,33 @@ import Login from '@/pages/Login'
 import PasswordReset from '@/pages/PasswordReset'
 import Register from '@/pages/Register'
 
+const RequireNoAuth = () => {
+  const { isLoggedIn } = useSelector((state: RootState) => state.auth)
+
+  // 로그인 상태면 접근 불가 → 홈으로 이동
+  if (isLoggedIn) return <Navigate to='/' replace />
+
+  return <Outlet />
+}
+
 const router = createBrowserRouter([
   {
-    children: [
-      { element: <Home />, index: true },
-      { element: <Login />, path: 'login' },
-      { element: <Register />, path: 'register' },
-      { element: <PasswordReset />, path: 'password-reset' },
-    ],
     element: <RootLayout />,
     path: '/',
+    children: [
+      { element: <Home />, index: true },
+
+      // 로그인 상태면 접근 불가 라우트
+      {
+        element: <RequireNoAuth />,
+        children: [
+          { element: <Login />, path: 'login' },
+          { element: <Register />, path: 'register' },
+          { element: <PasswordReset />, path: 'password-reset' },
+        ],
+      },
+    ],
   },
 ])
+
 export default router

--- a/src/utils/errorGuards.ts
+++ b/src/utils/errorGuards.ts
@@ -1,0 +1,20 @@
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+
+// RTK Query에서 발생하는 FetchBaseQueryError인지 확인하는 타입 가드
+export const isFetchBaseQueryError = (
+  error: unknown,
+): error is FetchBaseQueryError => {
+  return typeof error === 'object' && error !== null && 'status' in error
+}
+
+// 에러 객체에 서버에서 전달한 메시지(data.message)가 있는지 확인하는 타입 가드
+export const hasMessage = (
+  error: unknown,
+): error is { data: { message: string } } => {
+  // error가 객체인지 확인
+  if (typeof error !== 'object' || error === null) return false
+
+  // data.message 존재 여부 체크
+  const maybeError = error as { data?: { message?: unknown } }
+  return typeof maybeError.data?.message === 'string'
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#21 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### ✅ BackSheet 
로그인 - 회원가입 - 비밀번호 찾기 페이지에서 사용되는 그라데이션 배경 + 화이트 박스 배경 컴포넌트 제작했습니다.

### ✅ 로그인 
기존의 로그인 UI 에서 회원가입 버튼 및 BackSheet를 붙여 작업했습니다.

### ✅ 회원가입
기존의 회원가입에 UI 수정 및 form 에서 훅을 분리하여 작업했습니다.

### ✅ 루트 수정

```
// 로그인 상태면 접근 불가 라우트
      {
        element: <RequireNoAuth />,
        children: [
          { element: <Login />, path: 'login' },
          { element: <Register />, path: 'register' },
          { element: <PasswordReset />, path: 'password-reset' },
        ],
      },
```

로그인 상태일 때 로그인, 회원가입, 비밀번호 찾기 페이지로 이동이 불가능하게 route 파일 수정했습니다.

### 스크린샷 (선택)

<img width="1421" height="689" alt="image" src="https://github.com/user-attachments/assets/4ba6cab4-85ba-438b-ace0-3a3a6d4c1ab5" />

<img width="1422" height="696" alt="image" src="https://github.com/user-attachments/assets/328cba40-18df-4098-bad8-b841f2e4bddc" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

루트 파일 수정 떄문에 혹시 문제 있으면 알려주세요 ~!