### PR TITLE
[✨][Feat]#29: refreshToken 구현

### DIFF
--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -46,6 +46,7 @@ export const useLogin = () => {
           setCredentials({
             isLoggedIn: true, // 로그인 상태
             accessToken: result.data.accessToken, // 액세스 토큰
+            refreshToken: result.data.refreshToken,
             userId: result.data.userId ?? 0, // ID 값
             nickname: result.data.nickname ?? '', // 닉네임
             email, // 이메일

--- a/src/hooks/useTokenRefresh.ts
+++ b/src/hooks/useTokenRefresh.ts
@@ -1,0 +1,36 @@
+import { UserApi } from '@/services/endpoints/user'
+import { useDispatch, useSelector } from 'react-redux'
+import { setCredentials } from '@/store/slices/authSlice'
+import type { AppDispatch, RootState } from '@/store/store'
+
+export const useTokenRefresh = () => {
+  const dispatch = useDispatch<AppDispatch>()
+  const [reissue] = UserApi.useReissueMutation()
+  const auth = useSelector((state: RootState) => state.auth)
+
+  const refreshAccessToken = async () => {
+    if (!auth.refreshToken) return null
+
+    try {
+      const result = await reissue({
+        tokenRefreshRequest: { refreshToken: auth.refreshToken },
+      }).unwrap()
+      if (result.data) {
+        // 새 accessToken 받으면 Redux와 localStorage 업데이트
+        dispatch(
+          setCredentials({
+            ...auth,
+            accessToken: result.data,
+          }),
+        )
+        return result.data
+      }
+    } catch (err) {
+      console.error('토큰 재발급 실패:', err)
+
+      return null
+    }
+  }
+
+  return { refreshAccessToken }
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,16 +1,72 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import {
+  createApi,
+  fetchBaseQuery,
+  type BaseQueryFn,
+  type FetchArgs,
+  type FetchBaseQueryError,
+} from '@reduxjs/toolkit/query/react'
+import { UserApi } from './endpoints/user'
+import { setCredentials, logout } from '@/store/slices/authSlice'
+import type { RootState } from '@/store/store'
 
-export const api = createApi({
-  baseQuery: fetchBaseQuery({
+// fetchBaseQuery 타입 지정
+const baseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> =
+  fetchBaseQuery({
     baseUrl: '/',
     prepareHeaders: (headers, { getState }) => {
-      const token = (getState() as any).auth.accessToken
-      if (token) {
-        headers.set('Authorization', `Bearer ${token}`)
-      }
+      const token = (getState() as RootState).auth.accessToken
+      if (token) headers.set('Authorization', `Bearer ${token}`)
       return headers
     },
-  }),
+  })
+
+// Access Token 재발급 로직 포함
+const baseQueryWithReauth: BaseQueryFn<
+  string | FetchArgs,
+  unknown,
+  FetchBaseQueryError
+> = async (args, api, extraOptions) => {
+  let result = await baseQuery(args, api, extraOptions)
+
+  if (result.error?.status === 401) {
+    const refreshToken = (api.getState() as RootState).auth.refreshToken
+    if (!refreshToken) {
+      api.dispatch(logout())
+      return result
+    }
+
+    try {
+      const reissueResult = await api
+        .dispatch(
+          UserApi.endpoints.reissue.initiate({
+            tokenRefreshRequest: { refreshToken },
+          }),
+        )
+        .unwrap()
+
+      if (reissueResult.data) {
+        // Redux와 localStorage에 새 토큰 저장
+        api.dispatch(
+          setCredentials({
+            ...(api.getState() as RootState).auth,
+            accessToken: reissueResult.data,
+          }),
+        )
+
+        // 원래 요청 재실행
+        result = await baseQuery(args, api, extraOptions)
+      }
+    } catch {
+      api.dispatch(logout())
+    }
+  }
+
+  return result
+}
+
+// RTK Query Api 생성
+export const api = createApi({
+  baseQuery: baseQueryWithReauth,
   endpoints: (builder) => ({
     user: builder.query<{ status: string }, void>({
       query: () => 'user',

--- a/src/services/endpoints/user-emoji.ts
+++ b/src/services/endpoints/user-emoji.ts
@@ -11,6 +11,21 @@ const injectedRtkApi = api.injectEndpoints({
         body: queryArg.body,
       }),
     }),
+    getComments: build.query<GetCommentsApiResponse, GetCommentsApiArg>({
+      query: (queryArg) => ({
+        url: `/api/user-emojis/${queryArg.userEmojiId}/comments`,
+      }),
+    }),
+    createComment: build.mutation<
+      CreateCommentApiResponse,
+      CreateCommentApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/user-emojis/${queryArg.userEmojiId}/comments`,
+        method: 'POST',
+        body: queryArg.commentCreateRequest,
+      }),
+    }),
     getUserEmojiDetail: build.query<
       GetUserEmojiDetailApiResponse,
       GetUserEmojiDetailApiArg
@@ -49,6 +64,16 @@ export type CreateUserEmojiApiArg = {
     images?: Blob[]
   }
 }
+export type GetCommentsApiResponse =
+  /** status 200 OK */ ApiResponseListCommentResponse
+export type GetCommentsApiArg = {
+  userEmojiId: number
+}
+export type CreateCommentApiResponse = /** status 200 OK */ ApiResponseVoid
+export type CreateCommentApiArg = {
+  userEmojiId: number
+  commentCreateRequest: CommentCreateRequest
+}
 export type GetUserEmojiDetailApiResponse =
   /** status 200 OK */ ApiResponseUserEmojiDetailResponse
 export type GetUserEmojiDetailApiArg = {
@@ -75,6 +100,25 @@ export type UserEmojiCreateRequest = {
   /** 내용 */
   text?: string
 }
+export type CommentResponse = {
+  commentId?: number
+  content?: string
+  authorNickname?: string
+  createdAt?: string
+}
+export type ApiResponseListCommentResponse = {
+  code?: string
+  message?: string
+  data?: CommentResponse[]
+}
+export type ApiResponseVoid = {
+  code?: string
+  message?: string
+  data?: object
+}
+export type CommentCreateRequest = {
+  content?: string
+}
 export type UserEmojiDetailResponse = {
   /** 유저 이모지 번호 */
   userEmojiId?: number
@@ -93,11 +137,6 @@ export type ApiResponseUserEmojiDetailResponse = {
   code?: string
   message?: string
   data?: UserEmojiDetailResponse
-}
-export type ApiResponseVoid = {
-  code?: string
-  message?: string
-  data?: object
 }
 export type LatestMyEmojiResponse = {
   /** 유저 이모지 번호 */
@@ -136,6 +175,9 @@ export type ApiResponseUserEmojiHighlightsResponse = {
 }
 export const {
   useCreateUserEmojiMutation,
+  useGetCommentsQuery,
+  useLazyGetCommentsQuery,
+  useCreateCommentMutation,
   useGetUserEmojiDetailQuery,
   useLazyGetUserEmojiDetailQuery,
   useDeleteUserEmojiMutation,

--- a/src/services/endpoints/user.ts
+++ b/src/services/endpoints/user.ts
@@ -210,6 +210,8 @@ export type EmailVerificationRequest = {
 export type PasswordResetRequest = {
   /** 인증 완료된 이메일 */
   email: string
+  /** 이메일로 발송된 인증 코드 */
+  verificationCode: string
   /** 새로운 비밀번호 */
   newPassword: string
 }

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -4,6 +4,7 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 export interface AuthState {
   isLoggedIn: boolean // 로그인 여부
   accessToken?: string // 로그인 성공 시 발급받은 JWT 토큰
+  refreshToken?: string //
   userId?: number // 로그인한 사용자 ID
   nickname?: string // 사용자 닉네임
   email?: string // 사용자 이메일
@@ -13,6 +14,7 @@ export interface AuthState {
 const initialState: AuthState = {
   isLoggedIn: false, // 기본값은 로그인 안 된 상태
   accessToken: undefined,
+  refreshToken: undefined,
   userId: undefined,
   nickname: undefined,
   email: undefined,
@@ -32,13 +34,10 @@ const authSlice = createSlice({
   initialState, // 초기 상태
   reducers: {
     // 로그인 성공 시 상태 업데이트
-    setCredentials: (state, action: PayloadAction<AuthState>) => {
-      state.isLoggedIn = true // 로그인 상태 true로 변경
-      state.accessToken = action.payload.accessToken
-      state.userId = action.payload.userId
-      state.nickname = action.payload.nickname
-      state.email = action.payload.email
-      // localStorage에도 상태 저장 → 새로고침 시 유지
+
+    setCredentials: (state, action: PayloadAction<Partial<AuthState>>) => {
+      Object.assign(state, action.payload)
+      state.isLoggedIn = !!state.accessToken
       localStorage.setItem('auth', JSON.stringify(state))
     },
 
@@ -46,6 +45,7 @@ const authSlice = createSlice({
     logout: (state) => {
       state.isLoggedIn = false
       state.accessToken = undefined
+      state.refreshToken = undefined
       state.userId = undefined
       state.nickname = undefined
       state.email = undefined


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#29 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### api 업데이트 
- 백엔드 api 업데이트 했습니다.

### refresh toekn
- useToekenRefresh hook 을 통해서 reissue api 를 연결하여 토큰 재발급 구현
- api 에서 기존의 액세스 토큰이 만료되어서 401 요청이 발생한 경우 리프레쉬 토큰으로 재발급을 받을 수 있도록 설정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

리프레쉬 토큰을 붙여봤는데 코드에 문제점이나 실행했을 때 에러 발견하면 코멘트 남겨주세요  ~!