### PR TITLE
[✨][Feat]#33: 회원가입 이메일 인증 구현

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -20,6 +20,7 @@ type InputProps = {
   showError?: boolean // 에러 메시지 표시 여부
   onErrorChange?: (error: string) => void
   timer?: React.ReactNode // 타이머
+  disabled?: boolean // 비활성화
 }
 
 const Input = ({
@@ -42,6 +43,7 @@ const Input = ({
   showError = true,
   onErrorChange,
   timer,
+  disabled = false,
 }: InputProps) => {
   const [value, setValue] = useState('')
   const [error, setError] = useState('')
@@ -107,6 +109,7 @@ const Input = ({
           onChange={handleChange}
           minLength={minLength}
           maxLength={maxLength}
+          disabled={disabled}
           className={`h-12 border rounded-xl px-4 transition-colors duration-300 focus:outline-none focus:ring-1 hover:border-orange_three font-normal text-sm sm:text-base 
             ${hasShadow ? 'shadow-md' : ''}
             ${inputPaddingRightClass}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -19,6 +19,7 @@ type InputProps = {
   containerClassName?: string // input 컨테이너 스타일 커스터마이징
   showError?: boolean // 에러 메시지 표시 여부
   onErrorChange?: (error: string) => void
+  timer?: React.ReactNode // 타이머
 }
 
 const Input = ({
@@ -40,6 +41,7 @@ const Input = ({
   containerClassName = '',
   showError = true,
   onErrorChange,
+  timer,
 }: InputProps) => {
   const [value, setValue] = useState('')
   const [error, setError] = useState('')
@@ -107,8 +109,9 @@ const Input = ({
           maxLength={maxLength}
           className={`h-12 border rounded-xl px-4 transition-colors duration-300 focus:outline-none focus:ring-1 hover:border-orange_three font-normal text-sm sm:text-base 
             ${hasShadow ? 'shadow-md' : ''}
-            ${error || errorMessage ? 'focus:ring-red-500' : 'focus:ring-orange_three'}
             ${inputPaddingRightClass}
+            ${timer} 
+            ${error || errorMessage ? 'focus:ring-red-500' : 'focus:ring-orange_three'}
             placeholder-gray_one
             placeholder:font-light
             ${inputSizeClasses[size]}
@@ -116,15 +119,21 @@ const Input = ({
         />
         {/* 입력 길이 표시 조건부 렌더링 */}
         {showLength && maxLength && (
-          <span className='absolute right-4 top-1/2 -translate-y-1/2 text-gray_one text-xs pointer-events-none'>
+          <span className='absolute right-4 top-12 text-gray_one text-xs pointer-events-none'>
             {value.length}/{maxLength}
+          </span>
+        )}
+        {/* timer 표시 */}
+        {timer && (
+          <span className='absolute right-4 top-12 text-gray_one text-xs pointer-events-none'>
+            {timer}
           </span>
         )}
       </div>
       {/* 에러 메시지 조건부 렌더링 */}
       {showError && (errorMessage || error) && (
         <p
-          className={`absolute -bottom-5 text-[10px] sm:text-[12px] mt-1 ${errorClassName}`}
+          className={`absolute -bottom-5 px-2 text-[10px] sm:text-[12px] mt-1 ${errorClassName}`}
         >
           {errorMessage || error}
         </p>

--- a/src/features/auth/RegisterForm.tsx
+++ b/src/features/auth/RegisterForm.tsx
@@ -22,6 +22,8 @@ const RegisterForm = () => {
     handleSendVerification,
     handleConfirmVerification,
     handleSignup,
+    emailConfirmError,
+    setEmailConfirmError,
   } = useRegister()
 
   const [emailError, setEmailError] = useState('')
@@ -70,6 +72,7 @@ const RegisterForm = () => {
             errorMessage={emailError}
             showError={!!emailError}
             onErrorChange={setEmailError}
+            disabled={isEmailVerified}
           />
           <Button
             label={
@@ -99,18 +102,20 @@ const RegisterForm = () => {
             errorMessage={
               emailVerifyMessage ? (
                 <span className='text-green_two'>{emailVerifyMessage}</span>
-              ) : emailError ? (
-                <span className='text-red_one'>{emailError}</span>
+              ) : emailConfirmError ? (
+                <span className='text-red_one'>{emailConfirmError}</span>
               ) : undefined
             }
-            showError={!!emailVerifyMessage || !!emailError}
-            onErrorChange={setEmailError}
+            showError={!!emailVerifyMessage || !!emailConfirmError}
+            onErrorChange={setEmailConfirmError}
             timer={
               verificationTimer.isActive
                 ? formatTime(verificationTimer.timeLeft)
                 : null
             }
+            disabled={isEmailVerified}
           />
+
           <Button
             label='인증 확인'
             type='button'

--- a/src/features/auth/RegisterForm.tsx
+++ b/src/features/auth/RegisterForm.tsx
@@ -1,7 +1,9 @@
 import Input from '@/components/Input'
 import Button from '@/components/Button'
 import { useRegister } from '@/hooks/useRegister'
+import { useTimer } from '@/hooks/useTimer'
 import { useState } from 'react'
+import { formatTime } from '@/utils/time'
 
 const RegisterForm = () => {
   const {
@@ -10,29 +12,52 @@ const RegisterForm = () => {
     password,
     confirmPassword,
     passwordMatchError,
-    apiError,
     isLoading,
+    emailVerifyMessage,
+    verificationCode,
+    setVerificationCode,
+    isEmailVerified,
     handlePasswordChange,
     handleConfirmPasswordChange,
+    handleSendVerification,
+    handleConfirmVerification,
     handleSignup,
   } = useRegister()
 
-  const [emailError, setEmailError] = useState<string>('')
-  const [passwordError, setPasswordError] = useState<string>('')
+  const [emailError, setEmailError] = useState('')
+  const [passwordError, setPasswordError] = useState('')
 
-  // 버튼 활성화 여부
-  const isButtonDisabled =
-    !email ||
-    !password ||
-    !!emailError ||
-    !!passwordError ||
-    !!passwordMatchError ||
-    isLoading
+  // 타이머 훅
+  const verificationTimer = useTimer(300) // 5분 인증번호 유효
+  const resendTimer = useTimer(30, false) // 30초 재전송 제한
+
+  const handleSendVerificationWithTimer = async () => {
+    await handleSendVerification()
+    verificationTimer.start() // 5분 타이머 시작
+    resendTimer.start() // 30초 재전송 제한 시작
+  }
+
+  // 인증 성공 시 5분 타이머 정지
+  if (isEmailVerified && verificationTimer.isActive) {
+    verificationTimer.stop()
+  }
+
+  const isAllFilled =
+    email &&
+    password &&
+    confirmPassword &&
+    verificationCode &&
+    !emailError &&
+    !passwordError &&
+    !passwordMatchError &&
+    isEmailVerified
+
+  const isButtonDisabled = !isAllFilled || isLoading
 
   return (
     <form onSubmit={handleSignup} className='flex flex-col'>
       <div className='space-y-7'>
-        {/* 이메일 입력 + 인증 버튼 */}
+        {/* 이메일 입력 + 인증번호 전송 버튼 */}
         <div className='flex items-end space-x-2 w-full'>
           <Input
             label='이메일'
@@ -47,11 +72,18 @@ const RegisterForm = () => {
             onErrorChange={setEmailError}
           />
           <Button
-            label='인증번호 전송'
+            label={
+              resendTimer.isActive
+                ? `${resendTimer.timeLeft}초 후 재전송`
+                : '인증번호 전송'
+            }
             type='button'
             size='m'
             baseButton
-            disabled={!!emailError || !email}
+            onClick={handleSendVerificationWithTimer}
+            disabled={
+              !!emailError || !email || isEmailVerified || resendTimer.isActive
+            }
           />
         </div>
 
@@ -62,14 +94,30 @@ const RegisterForm = () => {
             name='emailConfirm'
             type='text'
             placeholder='이메일 인증 번호'
+            onChange={(v) => setVerificationCode(v)}
             containerClassName='flex-1'
+            errorMessage={
+              emailVerifyMessage ? (
+                <span className='text-green_two'>{emailVerifyMessage}</span>
+              ) : emailError ? (
+                <span className='text-red_one'>{emailError}</span>
+              ) : undefined
+            }
+            showError={!!emailVerifyMessage || !!emailError}
+            onErrorChange={setEmailError}
+            timer={
+              verificationTimer.isActive
+                ? formatTime(verificationTimer.timeLeft)
+                : null
+            }
           />
           <Button
             label='인증 확인'
             type='button'
             size='m'
             baseButton
-            className='flex-none'
+            onClick={handleConfirmVerification}
+            disabled={!verificationCode || isEmailVerified}
           />
         </div>
 
@@ -98,9 +146,6 @@ const RegisterForm = () => {
           errorMessage={passwordMatchError}
           showError={!!passwordMatchError}
         />
-
-        {/* API 에러 메시지 (추후 토스트메시지로 개발 예정) */}
-        {apiError && <p className='text-red-500 text-sm'>{apiError}</p>}
       </div>
 
       {/* 회원가입 버튼 */}

--- a/src/features/modal/NickNameModal.tsx
+++ b/src/features/modal/NickNameModal.tsx
@@ -130,6 +130,7 @@ const NicknameForm = ({ onClose }: NicknameModalProps) => {
           required
           minLength={2}
           maxLength={20}
+          showLength
           onChange={(value) => setNickname(value)}
           errorMessage={error}
         />

--- a/src/hooks/useRegister.ts
+++ b/src/hooks/useRegister.ts
@@ -17,6 +17,7 @@ export const useRegister = () => {
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [verificationCode, setVerificationCode] = useState('')
+  const [emailConfirmError, setEmailConfirmError] = useState('')
 
   // 비밀번호 불일치 오류 메시지
   const [passwordMatchError, setPasswordMatchError] = useState('')
@@ -118,9 +119,9 @@ export const useRegister = () => {
       const userMessage = hasMessage(err)
         ? err.data.message
         : '인증에 실패했습니다.'
-      setApiError(userMessage)
       setIsEmailVerified(false)
-      console.error('인증 실패', err)
+      setEmailConfirmError(userMessage)
+      setEmailVerifyMessage('')
     }
   }
 
@@ -174,5 +175,7 @@ export const useRegister = () => {
     handleSendVerification,
     handleConfirmVerification,
     handleSignup,
+    emailConfirmError,
+    setEmailConfirmError,
   }
 }

--- a/src/hooks/useRegister.ts
+++ b/src/hooks/useRegister.ts
@@ -1,7 +1,8 @@
-import { useState } from 'react'
+import { useContext, useState } from 'react'
 import { UserApi } from '@/services/endpoints/user'
 import { useNavigate } from 'react-router-dom'
 import { hasMessage } from '@/utils/errorGuards'
+import { ToastContext } from '@/components/ToastProvider'
 
 /**
  * 회원가입 로직을 관리하는 훅
@@ -15,6 +16,7 @@ export const useRegister = () => {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
+  const [verificationCode, setVerificationCode] = useState('')
 
   // 비밀번호 불일치 오류 메시지
   const [passwordMatchError, setPasswordMatchError] = useState('')
@@ -22,12 +24,26 @@ export const useRegister = () => {
   // API 요청 실패 시 표시할 에러 메시지
   const [apiError, setApiError] = useState('')
 
+  // 인증 상태 메시지
+  const [emailVerifyMessage, setEmailVerifyMessage] = useState('')
+
+  // 인증 성공 여부
+  const [isEmailVerified, setIsEmailVerified] = useState(false)
+
   // 회원가입 요청 중 상태
   const [isLoading, setIsLoading] = useState(false)
 
   // RTK Query의 register mutation
   const [register] = UserApi.useRegisterMutation()
   const navigate = useNavigate()
+  const [sendVerificationEmail] = UserApi.useSendVerificationEmailMutation()
+  const [confirmVerificationEmail] =
+    UserApi.useConfirmVerificationEmailMutation()
+
+  // 토스트
+  const toastContext = useContext(ToastContext)
+  if (!toastContext) throw new Error('ToastProvider 필요!')
+  const { showToast } = toastContext
 
   /**
    * 비밀번호와 비밀번호 재확인이 일치하는지 검증
@@ -60,6 +76,54 @@ export const useRegister = () => {
     validatePasswords(password, value)
   }
 
+  // 이메일 인증번호 전송
+  const handleSendVerification = async (
+    e?: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    e?.preventDefault()
+    if (!email) return setApiError('이메일을 입력해주세요.')
+
+    try {
+      setApiError('')
+      setEmailVerifyMessage('')
+      setIsEmailVerified(false)
+      await sendVerificationEmail({
+        emailVerificationRequest: { email },
+      }).unwrap()
+      setEmailVerifyMessage('인증번호가 전송되었습니다.')
+    } catch (err: unknown) {
+      const userMessage = hasMessage(err)
+        ? err.data.message
+        : '인증번호 전송에 실패했습니다.'
+      setApiError(userMessage)
+    }
+  }
+
+  // 이메일 인증번호 확인
+  const handleConfirmVerification = async (
+    e?: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    e?.preventDefault()
+    if (!email || !verificationCode)
+      return setApiError('이메일과 인증번호를 입력해주세요.')
+
+    try {
+      await confirmVerificationEmail({
+        emailVerificationConfirmRequest: { email, verificationCode },
+      }).unwrap()
+      setIsEmailVerified(true)
+      setEmailVerifyMessage('인증 되었습니다.')
+      setApiError('')
+    } catch (err: unknown) {
+      const userMessage = hasMessage(err)
+        ? err.data.message
+        : '인증에 실패했습니다.'
+      setApiError(userMessage)
+      setIsEmailVerified(false)
+      console.error('인증 실패', err)
+    }
+  }
+
   /**
    * 회원가입 폼 제출 처리
    * - 비밀번호 일치 여부 확인
@@ -80,18 +144,19 @@ export const useRegister = () => {
       await register({
         registerRequest: { email, password, agreed: true },
       }).unwrap()
+      showToast({ message: '회원가입 완료!', messageType: 'success' })
       navigate('/login') // 성공 시 로그인 페이지로 이동
     } catch (err: unknown) {
       const userMessage = hasMessage(err)
         ? err.data.message
         : '회원가입에 실패했습니다.'
       setApiError(userMessage)
+      showToast({ message: userMessage, messageType: 'error' })
       console.error('회원가입 실패:', err)
     } finally {
       setIsLoading(false)
     }
   }
-
   return {
     email,
     setEmail,
@@ -100,8 +165,14 @@ export const useRegister = () => {
     passwordMatchError,
     apiError,
     isLoading,
+    emailVerifyMessage,
+    verificationCode,
+    setVerificationCode,
+    isEmailVerified,
     handlePasswordChange,
     handleConfirmPasswordChange,
+    handleSendVerification,
+    handleConfirmVerification,
     handleSignup,
   }
 }

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState, useCallback } from 'react'
+
+export const useTimer = (initialSeconds: number, autoStart = false) => {
+  const [timeLeft, setTimeLeft] = useState(initialSeconds)
+  const [isActive, setIsActive] = useState(autoStart)
+
+  useEffect(() => {
+    if (!isActive || timeLeft <= 0) return
+
+    const timer = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer)
+          setIsActive(false)
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [isActive, timeLeft])
+
+  const start = useCallback(() => {
+    setTimeLeft(initialSeconds)
+    setIsActive(true)
+  }, [initialSeconds])
+
+  const stop = useCallback(() => setIsActive(false), [])
+  const reset = useCallback(() => setTimeLeft(initialSeconds), [initialSeconds])
+
+  return { timeLeft, isActive, start, stop, reset }
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,5 @@
+export const formatTime = (seconds: number) => {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#33 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 이메일 인증 구현
- 회원가입 페이지에서 사용되는 이메일 인증 기능을 추가했습니다. 
- 회원가입 완료 후 토스트 메시지로 성공 / 실패 메시지가 나타나게 추가했습니다.

### 타이머 훅 개발 및 util 설정
- 이메일 인증 시 사용되는 타이머 기능을 구현했습니다.
- 인증 번호 전송 30초 이후에 재전송이 가능하게 버튼 타이머를 설정했습니다.
- 인증번호 입력은 인증 번호 전송 후 5분으로 타이머 설정했습니다.

### 컴포넌트 수정
- Input 컴포넌트에 타이머 css 관련 prop 를 추가하여 넣었습니다.
- Input disabled 로 비활성화 기능 추가하였습니다. ( 이메일 인증 완료 시 수정 불가 기능 )

```
  timer?: React.ReactNode // 타이머
  disabled?: boolean // 비활성화
 ```
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

회원가입 잘되는지 테스트 부탁드립니다 ~!