### PR TITLE
[✨][Feat]#35: 회원 관련 페이지 모바일 구현

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -33,7 +33,7 @@ const Button = ({
   // size prop에 따라 다르게 적용되는 너비 스타일을 정의합니다.
   const buttonSizeClasses =
     size === 's'
-      ? 'w-[140px]' // 140px
+      ? 'w-[120px]' // 140px
       : size === 'm'
         ? 'w-40 ' // 160px
         : size === 'l'

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -61,8 +61,7 @@ const Input = ({
 
     if (type === 'email') {
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-      if (!emailRegex.test(inputValue))
-        return '이메일 주소를 정확히 입력해주세요.'
+      if (!emailRegex.test(inputValue)) return '이메일을 다시 입력해주세요.'
     }
 
     if (type === 'password') {
@@ -136,7 +135,7 @@ const Input = ({
       {/* 에러 메시지 조건부 렌더링 */}
       {showError && (errorMessage || error) && (
         <p
-          className={`absolute -bottom-5 px-2 text-[10px] sm:text-[12px] mt-1 ${errorClassName}`}
+          className={`absolute -bottom-5 px-1 text-[10px] sm:text-[12px] mt-1 ${errorClassName}`}
         >
           {errorMessage || error}
         </p>

--- a/src/features/auth/AuthForm.tsx
+++ b/src/features/auth/AuthForm.tsx
@@ -4,6 +4,7 @@ import { useTimer } from '@/hooks/useTimer'
 import { useState } from 'react'
 import { formatTime } from '@/utils/time'
 import type { useAuthForm } from '@/hooks/useAuthForm'
+import useMobile from '@/hooks/useMobile'
 
 type AuthFormProps = ReturnType<typeof useAuthForm> & {
   submitButtonLabel: string
@@ -31,6 +32,7 @@ const AuthForm = ({
 }: AuthFormProps) => {
   const [emailError, setEmailError] = useState('')
   const [passwordError, setPasswordError] = useState('')
+  const isMobile = useMobile() // 모바일 구분
 
   // 타이머 훅
   const verificationTimer = useTimer(300)
@@ -88,8 +90,18 @@ const AuthForm = ({
   // 비밀번호 찾기 모드에서 인증 완료 시 이메일/인증 필드는 비활성화
   const isAuthFieldsDisabled = isEmailVerified && mode === 'passwordReset'
 
+  // 모바일 상단 헤더
+  const MobileHeader = (
+    <div className='w-full pt-8 pb-6'>
+      <h1 className='text-4xl font-extrabold text-orange_five'>MOZI</h1>
+      <p className='text-base font-medium mt-2'>
+        {mode === 'register' ? '회원가입' : '비밀번호 찾기'}
+      </p>
+    </div>
+  )
   return (
-    <form onSubmit={handleSubmit} className='flex flex-col'>
+    <form onSubmit={handleSubmit} className='flex flex-col px-12'>
+      {isMobile && MobileHeader}
       <div className='space-y-7'>
         {showAuthFields && (
           <>
@@ -115,7 +127,7 @@ const AuthForm = ({
                     : '인증번호 전송'
                 }
                 type='button'
-                size='m'
+                size='s'
                 baseButton
                 onClick={handleSendVerificationWithTimer}
                 disabled={
@@ -133,7 +145,7 @@ const AuthForm = ({
                 label='이메일 인증 번호'
                 name='emailConfirm'
                 type='text'
-                placeholder='이메일 인증 번호'
+                placeholder='인증 번호'
                 onChange={(v) => setVerificationCode(v)}
                 containerClassName='flex-1'
                 errorMessage={
@@ -152,7 +164,7 @@ const AuthForm = ({
               <Button
                 label='인증 확인'
                 type='button'
-                size='m'
+                size='s'
                 baseButton
                 onClick={handleConfirmVerification}
                 disabled={!verificationCode || isAuthFieldsDisabled}

--- a/src/hooks/useMobile.ts
+++ b/src/hooks/useMobile.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+
+// 모바일 브레이크포인트 기준 (768px)
+const MOBILE_BREAKPOINT = 768
+
+/**
+ * useMobile 훅
+ * - 현재 화면이 모바일 사이즈(<= 768px)인지 여부를 반환
+ * - 반응형 UI 구성 시 사용
+ */
+const useMobile = () => {
+  // 초기 상태: 브라우저가 존재할 경우 화면 너비로 판단, 아닐 경우 false
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined'
+      ? window.innerWidth <= MOBILE_BREAKPOINT
+      : false,
+  )
+
+  useEffect(() => {
+    // 화면 크기 변경될 때마다 모바일 여부를 갱신하는 함수
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= MOBILE_BREAKPOINT)
+    }
+
+    handleResize() // 초기 렌더 시 한 번 실행해서 현재 상태 반영
+
+    // 리사이즈 이벤트 리스너 등록
+    window.addEventListener('resize', handleResize)
+
+    // 컴포넌트 언마운트 시 이벤트 리스너 정리
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+
+  return isMobile // 모바일 여부 반환
+}
+
+export default useMobile

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -5,10 +5,12 @@ import type { RootState } from '@/store/store'
 import { useNavigate } from 'react-router-dom'
 import BackSheet from '@/components/BackSheet'
 import { useEffect } from 'react'
+import useMobile from '@/hooks/useMobile'
 
 const Login = () => {
   const { isLoggedIn } = useSelector((state: RootState) => state.auth)
   const navigate = useNavigate()
+  const isMobile = useMobile() // 모바일 여부 판단
 
   // 로그인 상태면 로그인 페이지 접근 차단
   useEffect(() => {
@@ -17,35 +19,67 @@ const Login = () => {
     }
   }, [isLoggedIn, navigate])
 
-  return (
-    <BackSheet>
-      <div className='flex w-full h-full justify-center'>
-        {/* 왼쪽 영역 */}
-        <div className='w-full flex flex-col justify-center p-12 rounded-l-xl'>
-          <h1 className='text-4xl font-extrabold text-orange_five'>MOZI</h1>
-          <p className='text-lg font-medium mt-4'>
-            당신의 하루, 하나의 이모지로 전하세요 😊
-          </p>
-          <p className='text-md pt-24'>
-            아직 가입하지 않으셨나요? <br />
-            가입하고 오늘의 기분을 남겨보세요
-          </p>
-          <Button
-            label='회원가입'
-            type='button'
-            onClick={() => navigate('/register')}
-            className='mt-6'
-          />
-        </div>
+  // 모바일 헤더
+  const MobileHeader = (
+    <div className='w-full px-12 pt-8'>
+      <h1 className='text-4xl font-extrabold text-orange_five'>MOZI</h1>
+      <p className='text-base font-medium mt-2'>
+        당신의 하루, 하나의 이모지로 전하세요 😊
+      </p>
+    </div>
+  )
 
-        <div className='absolute top-20 bottom-20 left-1/2 w-px bg-gray-300'></div>
-        {/* 오른쪽 로그인 영역 */}
+  const loginContent = (
+    <div className='flex flex-col w-full h-full items-center'>
+      {/* 모바일 상단 헤더 */}
+      {isMobile && MobileHeader}
+
+      <div className='flex w-full h-full justify-center'>
+        {/* 왼쪽 영역 (모바일에서는 숨김) */}
+        {!isMobile && (
+          <div className='w-full flex flex-col justify-center p-12 rounded-l-xl'>
+            <h1 className='text-4xl font-extrabold text-orange_five'>MOZI</h1>
+            <p className='text-lg font-medium mt-4'>
+              당신의 하루, 하나의 이모지로 전하세요 😊
+            </p>
+            <p className='text-md pt-24'>
+              아직 가입하지 않으셨나요? <br />
+              가입하고 오늘의 기분을 남겨보세요
+            </p>
+            <Button
+              label='회원가입'
+              type='button'
+              onClick={() => navigate('/register')}
+              className='mt-6'
+            />
+          </div>
+        )}
+
+        {/* 중앙 구분선 (모바일에서는 숨김) */}
+        {!isMobile && (
+          <div className='absolute top-20 bottom-20 left-1/2 w-px bg-gray_one'></div>
+        )}
+
+        {/* 로그인 폼 영역 */}
         <div className='w-full flex flex-col justify-center items-center p-12'>
           <LoginForm />
+
+          {/* 모바일 회원가입 버튼 */}
+          {isMobile && (
+            <Button
+              label='회원가입'
+              type='button'
+              onClick={() => navigate('/register')}
+              className='mt-8'
+            />
+          )}
         </div>
       </div>
-    </BackSheet>
+    </div>
   )
+
+  // 모바일과 PC 모드를 구분하여 return
+  return isMobile ? loginContent : <BackSheet>{loginContent}</BackSheet>
 }
 
 export default Login

--- a/src/pages/PasswordReset.tsx
+++ b/src/pages/PasswordReset.tsx
@@ -1,21 +1,29 @@
 import BackSheet from '@/components/BackSheet'
 import AuthForm from '@/features/auth/AuthForm'
 import { useAuthForm } from '@/hooks/useAuthForm'
+import useMobile from '@/hooks/useMobile'
 
 const PasswordReset = () => {
   const authFormProps = useAuthForm('passwordReset')
+  const isMobile = useMobile()
 
-  return (
-    <BackSheet showHeader={true} title='비밀번호 찾기'>
-      <div className='flex flex-col items-center justify-center w-full'>
-        <div className='w-full max-w-[448px]'>
-          <AuthForm
-            {...authFormProps}
-            mode='passwordReset'
-            submitButtonLabel='비밀번호 재설정'
-          />
-        </div>
+  const resetContent = (
+    <div className='flex flex-col items-center justify-center w-full'>
+      <div className='w-full max-w-[560px]'>
+        <AuthForm
+          {...authFormProps}
+          mode='passwordReset'
+          submitButtonLabel='비밀번호 재설정'
+        />
       </div>
+    </div>
+  )
+
+  return isMobile ? (
+    resetContent
+  ) : (
+    <BackSheet showHeader title='비밀번호 찾기'>
+      {resetContent}
     </BackSheet>
   )
 }

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,21 +1,29 @@
 import BackSheet from '@/components/BackSheet'
 import AuthForm from '@/features/auth/AuthForm'
 import { useAuthForm } from '@/hooks/useAuthForm'
+import useMobile from '@/hooks/useMobile'
 
 const Register = () => {
   const authFormProps = useAuthForm('register')
+  const isMobile = useMobile()
 
-  return (
-    <BackSheet showHeader={true} title='회원가입'>
-      <div className='flex flex-col items-center justify-center w-full'>
-        <div className='w-full max-w-[448px]'>
-          <AuthForm
-            {...authFormProps}
-            mode='register'
-            submitButtonLabel='회원가입 완료'
-          />
-        </div>
+  const registerContent = (
+    <div className='flex flex-col items-center justify-center w-full'>
+      <div className='w-full max-w-[560px]'>
+        <AuthForm
+          {...authFormProps}
+          mode='register'
+          submitButtonLabel='회원가입 완료'
+        />
       </div>
+    </div>
+  )
+
+  return isMobile ? (
+    registerContent
+  ) : (
+    <BackSheet showHeader title='회원가입'>
+      {registerContent}
     </BackSheet>
   )
 }

--- a/src/services/endpoints/user-emoji.ts
+++ b/src/services/endpoints/user-emoji.ts
@@ -103,6 +103,7 @@ export type UserEmojiCreateRequest = {
 export type CommentResponse = {
   commentId?: number
   content?: string
+  userId?: number
   authorNickname?: string
   createdAt?: string
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#35 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### ✅ 모바일 훅 개발

- `useMobile.ts` 훅에 `MOBILE_BREAKPOINT = 768` 로 설정하여 모바일 사이즈를 지정
- 화면의 크기가 변경될 때마다 사이즈를 갱신하여 반응형 구현
- `isMobile` 을 활용하여 다른 페이지에서 간편하게 모바일 반응형 구현 가능

###  ✅ 로그인 모바일 구현
```
return isMobile ? loginContent : <BackSheet>{loginContent}</BackSheet>
```
- 모바일인 경우 BackSheet 을 없애고 PC에서만 보여지게 구현

```
 {!isMobile && (
          <div ~~~/>
  )}
```
- PC에서만 보여지는 화면일 경우 위의 조건으로 사용


```
 {isMobile && (
          <div ~~~/>
  )}
```
- 모바일에서만 보여지는 화면일 경우 위의 조건으로 사용


###  ✅ 회원가입 - 비밀번호 찾기 모바일 구현
```
return isMobile ? (
    resetContent
  ) : (
    <BackSheet showHeader title='비밀번호 찾기'>
      {resetContent}
    </BackSheet>
  )
```
- 로그인과 마찬가지로 isMobile 활용하여 모바일과 PC 사이즈에 따라 반응형으로 구현

```
  // 모바일 상단 헤더
  const MobileHeader = (
    <div className='w-full pt-8 pb-6'>
      <h1 className='text-4xl font-extrabold text-orange_five'>MOZI</h1>
      <p className='text-base font-medium mt-2'>
        {mode === 'register' ? '회원가입' : '비밀번호 찾기'}
      </p>
    </div>
  )
```
- AuthForm 에서 공통으로 사용되지만 구분이 필요한 경우는 `{mode === 'register' ? '회원가입' : '비밀번호 찾기'}` 를 활용하여 mode에 따라 회원가입과 비밀번호 찾기를 구분하여 작성

### 스크린샷 (선택)

<img width="311" height="615" alt="image" src="https://github.com/user-attachments/assets/3f79fcad-4da5-4f69-ba78-5d5c30098d25" />

<img width="308" height="616" alt="image" src="https://github.com/user-attachments/assets/9bb7ec51-4cb7-4132-9678-241a4bb21094" />

<img width="308" height="615" alt="image" src="https://github.com/user-attachments/assets/4b20b7ce-5334-46bf-ae29-005446c25c68" />

### 비밀번호 찾기 로직
1. 이메일 인증 
2. 인증이 되면 인증 input 들이 사라지고 비밀번호 input으로 변경됨


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

반응형 훅 모바일 만들 때 사용하시면 됩니다~
