### PR TITLE
[✨][Feat]#43: 모바일 반응형 모달 구현

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -14,13 +14,13 @@ const Modal = ({
   size = 'md',
 }: ModalProps) => {
   const sizeClass =
-    size === 'sm' ? 'w-[280px]' : size === 'md' ? 'w-[580px]' : ''
+    size === 'sm' ? 'md:w-[280px]' : size === 'md' ? 'md:w-[580px]' : ''
 
   return (
     <AnimatePresence>
       {isOpen && (
         <motion.div
-          className='fixed inset-0 z-50 flex items-center justify-center'
+          className='fixed inset-0 z-50 flex items-center justify-center px-4'
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
@@ -36,7 +36,7 @@ const Modal = ({
 
           {/* 모달 컨텐츠 */}
           <motion.div
-            className={`bg-white p-16 rounded-xl z-10 ${sizeClass} ${className}`}
+            className={`bg-white z-10 p-6 md:p-16 rounded-lg md:rounded-xl w-full max-w-full ${sizeClass} ${className}`}
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.95 }}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,37 +1,41 @@
-import { useEffect, useState } from 'react';
-import successIcon from '../assets/success_icon.svg'; // 성공 아이콘
-import errorIcon from '../assets/error_icon.svg'; // 에러 아이콘
-import failIcon from '../assets/fail_icon.svg'; // 실패 아이콘
+import { useEffect, useState } from 'react'
+import successIcon from '../assets/success_icon.svg' // 성공 아이콘
+import errorIcon from '../assets/error_icon.svg' // 에러 아이콘
+import failIcon from '../assets/fail_icon.svg' // 실패 아이콘
 
 /**
  * Toast Message 컴포넌트가 사용할 수 있는 위치를 정의합니다.
- * 
+ *
  * top-center : 중앙 상단 (기본값)
- * 
+ *
  * bottom-center : 중앙 하단
- * 
+ *
  * bottom-left : 좌측 하단
- * 
+ *
  * bottom-right : 우측 하단
  */
-export type ToastPosition = 'top-center' | 'bottom-center' | 'bottom-left' | 'bottom-right';
+export type ToastPosition =
+  | 'top-center'
+  | 'bottom-center'
+  | 'bottom-left'
+  | 'bottom-right'
 
 /**
  * Toast Message 컴포넌트가 받을 수 있는 props의 타입을 정의합니다.
  */
 export type ToastProps = {
-  id?: number; // 상태 관리를 위한 고유 ID
-  message: string; // Toast Message에 표시될 내용
-  className?: string; // 스타일 커스텀 (Tailwind CSS)
-  messageType?: 'success' | 'fail' | 'error'; // Toast Message 유형을 설정합니다. (기본값: 'success')
-  size?: 's' | 'm' | 'l'; // Toast Message의 크기를 설정합니다. (기본값: 'm')
-  duration?: number; // Toast Message가 표시될 시간(ms)입니다. (기본값: 2000)
-  position?: ToastPosition; // Toast Message가 나타날 위치를 정합니다. (기본값: 'top-center')
-};
+  id?: number // 상태 관리를 위한 고유 ID
+  message: string // Toast Message에 표시될 내용
+  className?: string // 스타일 커스텀 (Tailwind CSS)
+  messageType?: 'success' | 'fail' | 'error' // Toast Message 유형을 설정합니다. (기본값: 'success')
+  size?: 's' | 'm' | 'l' // Toast Message의 크기를 설정합니다. (기본값: 'm')
+  duration?: number // Toast Message가 표시될 시간(ms)입니다. (기본값: 2000)
+  position?: ToastPosition // Toast Message가 나타날 위치를 정합니다. (기본값: 'top-center')
+}
 
 type IndividualToastProps = ToastProps & {
-  onDismiss: () => void;
-};
+  onDismiss: () => void
+}
 
 const Toast = ({
   message,
@@ -41,48 +45,47 @@ const Toast = ({
   className,
   onDismiss,
 }: IndividualToastProps) => {
-  const [visible, setVisible] = useState(true);
+  const [visible, setVisible] = useState(true)
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      setVisible(false);
+      setVisible(false)
       // 애니메이션 시간을 기다린 후 컴포넌트 제거
-      setTimeout(onDismiss, 200); // 200ms는 transition 시간과 일치시킵니다.
-    }, duration);
+      setTimeout(onDismiss, 200) // 200ms는 transition 시간과 일치시킵니다.
+    }, duration)
 
     return () => {
-      clearTimeout(timer);
-    };
-  }, [duration, onDismiss]);
+      clearTimeout(timer)
+    }
+  }, [duration, onDismiss])
 
   // 타입별 스타일: 흰색 배경, 2px 두께의 타입별 테두리, 타입별 아이콘 색상
   const typeClasses = {
     success: 'bg-white border-2 border-green_one',
     fail: 'bg-white border-2 border-yellow_one',
     error: 'bg-white border-2 border-red_one',
-  };
+  }
 
   // 사이즈별 텍스트 및 레이아웃 스타일
   const sizeClasses = {
     s: 'min-w-[220px] py-2 px-5 text-sm',
-    m: 'min-w-[270px] py-3 px-6 text-base', // 기본값
+    m: 'min-w-[270px] py-3 px-4 text-base', // 기본값
     l: 'min-w-[320px] py-4 px-8 text-xl',
-  };
+  }
 
   // 사이즈별 아이콘 크기 스타일
   const iconSizeClasses = {
     s: 'w-5 h-5',
     m: 'w-6 h-6',
     l: 'w-7 h-7',
-  };
+  }
 
   // 타입별 아이콘 이미지 소스
   const typeIconSources = {
     success: successIcon,
     fail: failIcon,
     error: errorIcon,
-  };
-
+  }
 
   return (
     <div
@@ -95,16 +98,16 @@ const Toast = ({
         ${className}
       `}
     >
-      <div className="flex items-center">
+      <div className='flex items-center'>
         <img
           src={typeIconSources[messageType]}
           alt={`${messageType} icon`}
           className={`mr-3 shrink-0 ${iconSizeClasses[size]}`}
         />
-        <span className="text-black">{message}</span>
+        <span className='text-black'>{message}</span>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default Toast;
+export default Toast

--- a/src/features/auth/AuthForm.tsx
+++ b/src/features/auth/AuthForm.tsx
@@ -17,7 +17,6 @@ const AuthForm = ({
   confirmPassword,
   passwordMatchError,
   isLoading,
-  emailVerifyMessage,
   verificationCode,
   setVerificationCode,
   isEmailVerified,
@@ -26,7 +25,6 @@ const AuthForm = ({
   handleSendVerification,
   handleConfirmVerification,
   handleSubmit,
-  emailConfirmError,
   submitButtonLabel,
   mode,
 }: AuthFormProps) => {
@@ -150,18 +148,13 @@ const AuthForm = ({
                 placeholder='인증 번호'
                 onChange={(v) => setVerificationCode(v)}
                 containerClassName='flex-1'
-                errorMessage={
-                  emailConfirmError ? (
-                    <span className='text-red_one'>{emailConfirmError}</span>
-                  ) : undefined
-                }
-                showError={!!emailVerifyMessage || !!emailConfirmError}
+                showError={false}
                 timer={
                   verificationTimer.isActive
                     ? formatTime(verificationTimer.timeLeft)
                     : null
                 }
-                disabled={isAuthComplete}
+                disabled={!isEmailSent || isAuthComplete}
               />
               <Button
                 label='인증 확인'

--- a/src/features/auth/AuthForm.tsx
+++ b/src/features/auth/AuthForm.tsx
@@ -33,6 +33,7 @@ const AuthForm = ({
   const [emailError, setEmailError] = useState('')
   const [passwordError, setPasswordError] = useState('')
   const isMobile = useMobile() // 모바일 구분
+  const [isEmailSent, setIsEmailSent] = useState(false)
 
   // 타이머 훅
   const verificationTimer = useTimer(300)
@@ -48,6 +49,7 @@ const AuthForm = ({
     if (isSuccess) {
       verificationTimer.start()
       resendTimer.start()
+      setIsEmailSent(true)
     }
   }
 
@@ -87,8 +89,8 @@ const AuthForm = ({
   const showAuthFields =
     mode === 'register' || (mode === 'passwordReset' && !isEmailVerified)
 
-  // 비밀번호 찾기 모드에서 인증 완료 시 이메일/인증 필드는 비활성화
-  const isAuthFieldsDisabled = isEmailVerified && mode === 'passwordReset'
+  // 인증 완료 후 인증 관련 input/button disable 처리
+  const isAuthComplete = isEmailVerified
 
   // 모바일 상단 헤더
   const MobileHeader = (
@@ -118,12 +120,12 @@ const AuthForm = ({
                 errorMessage={emailError}
                 showError={!!emailError}
                 onErrorChange={setEmailError}
-                disabled={isAuthFieldsDisabled}
+                disabled={isEmailSent || isEmailVerified}
               />
               <Button
                 label={
                   resendTimer.isActive
-                    ? `${resendTimer.timeLeft}초 후 재전송`
+                    ? `00:${resendTimer.timeLeft}`
                     : '인증번호 전송'
                 }
                 type='button'
@@ -133,8 +135,8 @@ const AuthForm = ({
                 disabled={
                   !!emailError ||
                   !email ||
-                  isAuthFieldsDisabled ||
-                  resendTimer.isActive
+                  resendTimer.isActive ||
+                  isAuthComplete
                 }
               />
             </div>
@@ -159,7 +161,7 @@ const AuthForm = ({
                     ? formatTime(verificationTimer.timeLeft)
                     : null
                 }
-                disabled={isAuthFieldsDisabled}
+                disabled={isAuthComplete}
               />
               <Button
                 label='인증 확인'
@@ -167,7 +169,7 @@ const AuthForm = ({
                 size='s'
                 baseButton
                 onClick={handleConfirmVerification}
-                disabled={!verificationCode || isAuthFieldsDisabled}
+                disabled={!verificationCode || isAuthComplete}
               />
             </div>
           </>

--- a/src/features/modal/LogoutModal.tsx
+++ b/src/features/modal/LogoutModal.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { useContext } from 'react'
 import { useNavigate } from 'react-router-dom'
 import Button from '@/components/Button'
 import { useLogoutMutation } from '@/services/endpoints/user'
 import { useDispatch } from 'react-redux'
 import { logout } from '@/store/slices/authSlice'
 import Modal from '@/components/Modal'
+import { ToastContext } from '@/components/ToastProvider'
 
 interface LogoutModalProps {
   isOpen: boolean
@@ -14,20 +15,29 @@ interface LogoutModalProps {
 const LogoutModal = ({ isOpen, onClose }: LogoutModalProps) => {
   const [logoutApi, { isLoading }] = useLogoutMutation()
   const dispatch = useDispatch()
-  const [error, setError] = useState<string | null>(null)
   const navigate = useNavigate()
+  const toast = useContext(ToastContext)
 
   const handleLogout = async () => {
     try {
-      setError(null)
       await logoutApi().unwrap()
       dispatch(logout())
       onClose()
-      alert('로그아웃되었습니다.') // 추후 토스트 메시지로 개발할 예정
+      toast?.showToast({
+        message: '로그아웃되었습니다.',
+        messageType: 'success',
+        duration: 2000,
+        position: 'top-center',
+      })
       navigate('/login') // 로그아웃 후 로그인 페이지로 이동
     } catch (e) {
       console.error('로그아웃 실패', e)
-      setError('로그아웃 중 오류가 발생했습니다.')
+      toast?.showToast({
+        message: '로그아웃에 실패하였습니다.',
+        messageType: 'error',
+        duration: 2500,
+        position: 'top-center',
+      })
     }
   }
 
@@ -35,10 +45,9 @@ const LogoutModal = ({ isOpen, onClose }: LogoutModalProps) => {
     <Modal isOpen={isOpen} size='md'>
       <div className='px-4 flex flex-col items-center text-center'>
         <h2 className='text-xl font-semibold mb-4'>로그아웃</h2>
-        <p className='text-lg text-gray-600 mb-6'>로그아웃 하시겠습니까?</p>
-
-        {/* 토스트메시지로 개발할 예정 */}
-        {error && <p className='text-red_one text-sm'>{error}</p>}
+        <p className='text-base md:text-lg text-gray-600 mb-6'>
+          로그아웃 하시겠습니까?
+        </p>
 
         <div className='flex justify-center gap-6 mt-4 w-full'>
           <Button

--- a/src/features/modal/NickNameModal.tsx
+++ b/src/features/modal/NickNameModal.tsx
@@ -119,7 +119,9 @@ const NicknameForm = ({ onClose }: NicknameModalProps) => {
         await handleSubmit()
       }}
     >
-      <p className='text-lg font-medium mb-4'>닉네임을 입력해주세요</p>
+      <p className='md:text-lg  text-base font-medium mb-4'>
+        닉네임을 입력해주세요
+      </p>
 
       {/* 닉네임 입력 필드 */}
       <div className='relative'>

--- a/src/features/modal/WithdrawalModal.tsx
+++ b/src/features/modal/WithdrawalModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useContext, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useWithdrawMutation } from '@/services/endpoints/user'
 import { useDispatch } from 'react-redux'
@@ -6,6 +6,7 @@ import { logout } from '@/store/slices/authSlice'
 import Button from '@/components/Button'
 import Modal from '@/components/Modal'
 import Input from '@/components/Input'
+import { ToastContext } from '@/components/ToastProvider'
 
 interface WithdrawalModalProps {
   isOpen: boolean
@@ -17,20 +18,29 @@ const WithdrawalModal = ({ isOpen, onClose }: WithdrawalModalProps) => {
   const [withdraw, { isLoading }] = useWithdrawMutation()
   const navigate = useNavigate()
   const dispatch = useDispatch()
-  const [error, setError] = useState<string | null>(null)
   const [passwordError, setPasswordError] = useState<string>('')
+  const toast = useContext(ToastContext)
 
   const handleWithdrawal = async () => {
     try {
-      setError(null)
       await withdraw({ userWithdrawalRequest: { password } }).unwrap()
       dispatch(logout())
       onClose()
-      alert('회원탈퇴가 완료되었습니다.') // 추후 토스트 메시지로 개발할 예정
+      toast?.showToast({
+        message: '회원탈퇴가 완료되었습니다.',
+        messageType: 'success',
+        duration: 2500,
+        position: 'top-center',
+      })
       navigate('/login')
     } catch (err: any) {
       console.error('회원탈퇴 실패:', err)
-      setError(err?.data?.message || '비밀번호를 다시 입력해주세요.')
+      toast?.showToast({
+        message: err?.data?.message || '비밀번호를 다시 입력해주세요.',
+        messageType: 'error',
+        duration: 2500,
+        position: 'top-center',
+      })
     }
   }
 
@@ -41,9 +51,9 @@ const WithdrawalModal = ({ isOpen, onClose }: WithdrawalModalProps) => {
     <Modal isOpen={isOpen} size='md'>
       <div className='px-4 flex flex-col items-center text-center'>
         <h2 className='text-xl font-semibold mb-4'>회원탈퇴</h2>
-        <p className='text-lg mb-4'>
+        <p className='text-base md:text-lg mb-4'>
           정말 탈퇴하시겠습니까? <br />
-          계정은 삭제되며 복구되지 않습니다.
+          삭제된 계정은 복구되지 않습니다.
         </p>
         <div className='w-full'>
           <Input
@@ -55,8 +65,6 @@ const WithdrawalModal = ({ isOpen, onClose }: WithdrawalModalProps) => {
             onErrorChange={setPasswordError}
           ></Input>
         </div>
-        {/* 토스트메시지로 개발할 예정 */}
-        {error && <p className='text-red_one text-sm'>{error}</p>}
 
         <div className='flex justify-center gap-6 mt-8 w-full'>
           <Button

--- a/src/hooks/useAuthForm.ts
+++ b/src/hooks/useAuthForm.ts
@@ -131,8 +131,11 @@ export const useAuthForm = (mode: AuthMode) => {
         ? err.data.message
         : '인증에 실패했습니다.'
       setIsEmailVerified(false)
-      setEmailConfirmError(userMessage)
       setEmailVerifyMessage('')
+      showToast({
+        message: userMessage,
+        messageType: 'error',
+      })
     }
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#43 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### ✅ 모바일 반응형 모달 구현
- 모달 사이즈 반응형으로 변경 ( 모달 컴포넌트에서 변경하여 사용하는 다른 곳에서 추가 수정 필요 X )
- 닉네임 / 회원탈퇴 / 로그아웃 모달에 적용
``` 
 size === 'sm' ? 'md:w-[280px]' : size === 'md' ? 'md:w-[580px]' : ''
```

### ✅ 토스트 메시지 추가 및 수정
- 회원가입, 회원탈퇴, 로그아웃에서 사용되는 성공, 실패 메시지를 토스트로 구현
- 토스트 컴포넌트 사이즈 css 수정 ( 성공, 실패 텍스트 메시지가 두 줄이 되는 경우가 있어서 px 값 수정 )
``` 
    m: 'min-w-[270px] py-3 px-6 text-base', // 기존값
    m: 'min-w-[270px] py-3 px-4 text-base', // 변경값
```

### ✅ 이메일 인증 관련 수정
- 이메일 인증 번호가 전송되면 이메일 input 변경 불가능 및 인증 번호 input 활성화 ( 전송 전에는 비활성화 )
- 이메일 인증이 완료되면 번호 전송버튼, 인증번호 input, 인증확인 버튼 비활성화 ( 입력 값들이 변경되지 않도록 disabled 처리 )
 
### 스크린샷 (선택)

<img width="310" height="615" alt="image" src="https://github.com/user-attachments/assets/9cba3bd8-cc92-40cf-844d-5c4ef530e36c" />
<img width="312" height="610" alt="image" src="https://github.com/user-attachments/assets/cff5200d-ff61-4733-a0ca-c38597589197" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?