### PR TITLE
[🐛][Fix]#45: Chrome Input 경고 메시지 해결

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -21,6 +21,7 @@ type InputProps = {
   onErrorChange?: (error: string) => void
   timer?: React.ReactNode // 타이머
   disabled?: boolean // 비활성화
+  autoComplete?: string
 }
 
 const Input = ({
@@ -44,6 +45,7 @@ const Input = ({
   onErrorChange,
   timer,
   disabled = false,
+  autoComplete,
 }: InputProps) => {
   const [value, setValue] = useState('')
   const [error, setError] = useState('')
@@ -109,6 +111,7 @@ const Input = ({
           minLength={minLength}
           maxLength={maxLength}
           disabled={disabled}
+          autoComplete={autoComplete}
           className={`h-12 border rounded-xl px-4 transition-colors duration-300 focus:outline-none focus:ring-1 hover:border-orange_three font-normal text-sm sm:text-base 
             ${hasShadow ? 'shadow-md' : ''}
             ${inputPaddingRightClass}

--- a/src/features/auth/AuthForm.tsx
+++ b/src/features/auth/AuthForm.tsx
@@ -148,6 +148,7 @@ const AuthForm = ({
                 placeholder='인증 번호'
                 onChange={(v) => setVerificationCode(v)}
                 containerClassName='flex-1'
+                autoComplete='one-time-code'
                 showError={false}
                 timer={
                   verificationTimer.isActive
@@ -180,6 +181,7 @@ const AuthForm = ({
               errorMessage={passwordError}
               showError={!!passwordError}
               onErrorChange={setPasswordError}
+              autoComplete='new-password'
             />
 
             {/* 비밀번호 재확인 */}
@@ -193,6 +195,7 @@ const AuthForm = ({
               onChange={handleConfirmPasswordChange}
               errorMessage={passwordMatchError}
               showError={!!passwordMatchError}
+              autoComplete='new-password'
             />
           </>
         )}

--- a/src/features/auth/LoginForm.tsx
+++ b/src/features/auth/LoginForm.tsx
@@ -38,6 +38,7 @@ const LoginForm = () => {
           required
           onChange={(value) => setEmail(value)}
           onErrorChange={setEmailError}
+          autoComplete='username'
         />
         <Input
           label='비밀번호'
@@ -47,6 +48,7 @@ const LoginForm = () => {
           required
           onChange={(value) => setPassword(value)}
           onErrorChange={setPasswordError}
+          autoComplete='current-password'
         />
         {error && <p className='text-red-500 text-sm'>{error}</p>}
       </div>

--- a/src/features/modal/WithdrawalModal.tsx
+++ b/src/features/modal/WithdrawalModal.tsx
@@ -49,7 +49,16 @@ const WithdrawalModal = ({ isOpen, onClose }: WithdrawalModalProps) => {
 
   return (
     <Modal isOpen={isOpen} size='md'>
-      <div className='px-4 flex flex-col items-center text-center'>
+      <form className='px-4 flex flex-col items-center text-center'>
+        {/* 숨겨진 username 필드 (브라우저 검사용) */}
+        <input
+          type='text'
+          name='username'
+          autoComplete='username'
+          value='hidden-user'
+          style={{ display: 'none' }}
+          readOnly
+        />
         <h2 className='text-xl font-semibold mb-4'>회원탈퇴</h2>
         <p className='text-base md:text-lg mb-4'>
           정말 탈퇴하시겠습니까? <br />
@@ -61,6 +70,7 @@ const WithdrawalModal = ({ isOpen, onClose }: WithdrawalModalProps) => {
             name='password'
             type='password'
             placeholder='비밀번호를 입력하세요'
+            autoComplete='new-password'
             onChange={(e) => setPassword(e)}
             onErrorChange={setPasswordError}
           ></Input>
@@ -76,7 +86,7 @@ const WithdrawalModal = ({ isOpen, onClose }: WithdrawalModalProps) => {
           />
           <Button label='취소' onClick={onClose} />
         </div>
-      </div>
+      </form>
     </Modal>
   )
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#45 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### Input 경고 해결
- 회원가입, 로그인, 비밀번호 찾기 등에서 사용되는 이메일, 비밀번호 input에 관해 접근성 경고를 autocomplete 추가하여 해결
- 브라우저에서 autocomplete 속성을 명시
- `autocomplete='new-password'` 와 같이 수정함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?