### PR TITLE
[🐛][Fix]#50: vercel api 경로 에러 수정

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 @tailwind utilities;
 
 :root {
-  font-family: 'Wanted Sans Std Variable', 'Wanted Sans Std';
+  font-family: 'Wanted Sans Std Variable', 'Wanted Sans Std', sans-serif;
   line-height: 1.5;
   font-weight: 400;
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -12,7 +12,7 @@ import type { RootState } from '@/store/store'
 // fetchBaseQuery 타입 지정
 const baseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> =
   fetchBaseQuery({
-    baseUrl: '/',
+    baseUrl: import.meta.env.VITE_API_BASE_URL,
     prepareHeaders: (headers, { getState }) => {
       const token = (getState() as RootState).auth.accessToken
       if (token) headers.set('Authorization', `Bearer ${token}`)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#50 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### vercel api 경로 에러 수정
- Vercel 에서 프론트 도메인 https://mozi-psi.vercel.app 으로 api 요청 에러
- ` baseUrl: '/' ` 로컬에서는 froxy로 작동 O
- Vercel에서는 baseUrl 에 백엔드 주소를 넣어줌 ` baseUrl: import.meta.env.VITE_API_BASE_URL,`

### safari 폰트 에러
- safari 에서 wantedSans 적용이 되지 않는 문제가 발생
- 폰트 적용이 안되었을 때를 대비하여 `sans-serif` 기본 폰트 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?