### PR TITLE
[✨][Feat]#53: 마이페이지 반응형 구현 및 수정

### DIFF
--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -25,11 +25,12 @@ export type BottomSheetProps = {
 /**
  * 기본 바텀시트 컴포넌트
  * - 하단 슬라이드 인 애니메이션
- * - Header, Content 슬롯 제공
+ * - Header, Content, Footer 슬롯 제공
  */
 const BottomSheet: React.FC<BottomSheetProps> & {
   Header: typeof BottomSheetHeader
   Content: typeof BottomSheetContent
+  Footer: typeof BottomSheetFooter
 } = ({
   children,
   className,
@@ -94,12 +95,8 @@ const BottomSheet: React.FC<BottomSheetProps> & {
   const endDrag = () => {
     if (!isDragging) return
     setIsDragging(false)
-
-    if (translateY > 120) {
-      onClose()
-    } else {
-      setTranslateY(0)
-    }
+    if (translateY > 120) onClose()
+    else setTranslateY(0)
   }
 
   return (
@@ -158,9 +155,11 @@ const BottomSheet: React.FC<BottomSheetProps> & {
             onMouseDown={(e) => startDrag(e.clientY)}
             onTouchStart={(e) => startDrag(e.touches[0].clientY)}
           >
-            <div className='w-28 h-1.5 bg-gray-300 rounded-full' />
+            <div className='w-20 h-1.5 bg-gray-300 rounded-full' />
           </div>
-          <div className='flex-1 overflow-y-auto'>{children}</div>
+
+          {/* 실제 콘텐츠 영역 */}
+          <div className='flex-1 flex flex-col h-full'>{children}</div>
         </aside>
       </div>
     </BottomSheetContext.Provider>
@@ -172,21 +171,25 @@ const BottomSheet: React.FC<BottomSheetProps> & {
  */
 const BottomSheetHeader: React.FC<{ children: React.ReactNode }> = ({
   children,
-}) => {
-  return <div className='flex-shrink-0 px-6 pt-6'>{children}</div>
-}
+}) => <div className='flex-shrink-0 px-6'>{children}</div>
 
 /**
  * 바텀시트 콘텐츠 컴포넌트
  */
 const BottomSheetContent: React.FC<{ children: React.ReactNode }> = ({
   children,
-}) => {
-  return <div className='flex-1 overflow-y-auto px-6'>{children}</div>
-}
+}) => <div className='flex-1 overflow-y-auto px-6'>{children}</div>
 
-// 복합 컴포넌트 패턴 설정 (Header, Content만)
+/**
+ * 바텀시트 푸터 컴포넌트
+ */
+const BottomSheetFooter: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => <div className='flex-shrink-0 px-6 pb-6 pt-3'>{children}</div>
+
+// 복합 컴포넌트 패턴 설정
 BottomSheet.Header = BottomSheetHeader
 BottomSheet.Content = BottomSheetContent
+BottomSheet.Footer = BottomSheetFooter
 
 export default BottomSheet

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,29 +1,41 @@
-import logoImage from '../assets/logo.svg'
+'use client'
 
+import logoImage from '../assets/logo.svg'
+import { useNavigate } from 'react-router-dom'
 /**
  * Logo 컴포넌트가 받을 수 있는 props의 타입을 정의합니다.
  */
 type LogoProps = {
-  size?: 's' | 'm' | 'l' // 로고의 크기를 설정합니다. (기본값: 'm')
-  onClick?: () => void // 로고 클릭 시 실행될 함수입니다. (기본값: 없음)
+  size?: 'xs' | 's' | 'm' | 'l' // 로고의 크기를 설정합니다. (기본값: 'm')
+  navigateOnClick?: boolean // 클릭 시 홈('/')으로 이동할지 여부
 }
 
-const Logo = ({ size = 'm', onClick }: LogoProps) => {
+const Logo = ({ size = 'm', navigateOnClick = false }: LogoProps) => {
+  const navigate = useNavigate()
+
   const sizeClasses = {
-    s: 'w-16 h-16', // 작은 사이즈
+    xs: 'w-16 h-16', // 작은 사이즈
+    s: 'w-20 h-20', // 추가 사이즈
     m: 'w-24 h-24', // 중간 사이즈 (기본값)
     l: 'w-32 h-32', // 큰 사이즈
   }
 
   // onClick 핸들러가 있을 경우 커서를 포인터로 변경하여 클릭 가능함을 알립니다.
-  const interactiveClasses = onClick ? 'cursor-pointer' : ''
+  const interactiveClasses = navigateOnClick ? 'cursor-pointer' : ''
+
+  // 클릭 시 홈으로 이동
+  const handleClick = () => {
+    if (navigateOnClick) {
+      navigate('/')
+    }
+  }
 
   return (
     <img
       src={logoImage}
-      alt="Mozi 로고"
+      alt='Mozi 로고'
       className={`${sizeClasses[size]} ${interactiveClasses}`}
-      onClick={onClick}
+      onClick={handleClick}
     />
   )
 }

--- a/src/features/mypage/index.tsx
+++ b/src/features/mypage/index.tsx
@@ -1,10 +1,13 @@
 import { useState } from 'react'
 import SideSheet from '@/components/SideSheet'
+import BottomSheet from '@/components/BottomSheet'
 import Button from '@/components/Button'
 import { useSelector } from 'react-redux'
 import type { RootState } from '@/store/store'
 import LogoutModal from '@/features/modal/LogoutModal'
 import WithdrawalModal from '@/features/modal/WithdrawalModal'
+import useMobile from '@/hooks/useMobile'
+import Logo from '@/components/Logo'
 
 const MyPage = () => {
   const [isOpen, setIsOpen] = useState(false)
@@ -12,29 +15,44 @@ const MyPage = () => {
   const [isWithdrawalModalOpen, setIsWithdrawalModalOpen] = useState(false)
   const { nickname, email } = useSelector((state: RootState) => state.auth)
 
-  return (
-    <div>
-      {/* 추후 홈에서 마이페이지 버튼 추가하면 삭제 예정 */}
-      <Button
-        label='마이페이지'
-        onClick={() => setIsOpen(true)}
-        baseButton
-        size='s'
-      />
+  const isMobile = useMobile() // 현재 화면이 모바일인지 확인
 
-      <SideSheet isOpen={isOpen} onClose={() => setIsOpen(false)}>
-        {/* 마이페이지 컨텐츠 영역 */}
+  // 공통 콘텐츠 (SideSheet / BottomSheet 둘 다에서 사용)
+  const sheetContent = (
+    <>
+      {isMobile ? (
+        <BottomSheet.Content>
+          <Logo size='s'></Logo>
+          <p className='text-lg pb-1'>{nickname} 님</p>
+          <p className='text-lg'>{email}</p>
+        </BottomSheet.Content>
+      ) : (
         <SideSheet.Content>
-          <div className='p-12 space-y-4'>
-            <p className='text-5xl font-extrabold text-orange_five'>MOZI</p>
-            <p className='text-xl'>{nickname} 님</p>
+          <div className='px-10'>
+            <Logo size='l'></Logo>
+            <p className='text-xl pb-2'>{nickname} 님</p>
             <p className='text-xl'>{email}</p>
           </div>
         </SideSheet.Content>
-
-        {/* 마이페이지 푸터 버튼 영역 */}
+      )}
+      {/* 푸터 버튼 */}
+      {isMobile ? (
+        <BottomSheet.Footer>
+          <div className='space-y-4'>
+            <Button
+              label='로그아웃'
+              baseButton
+              onClick={() => setIsLogoutModalOpen(true)}
+            />
+            <Button
+              label='회원탈퇴'
+              onClick={() => setIsWithdrawalModalOpen(true)}
+            />
+          </div>
+        </BottomSheet.Footer>
+      ) : (
         <SideSheet.Footer>
-          <div className='p-12 space-y-6'>
+          <div className='p-10 space-y-6'>
             <Button
               label='로그아웃'
               baseButton
@@ -46,7 +64,30 @@ const MyPage = () => {
             />
           </div>
         </SideSheet.Footer>
-      </SideSheet>
+      )}
+    </>
+  )
+
+  return (
+    <div>
+      {/* 추후 홈에서 마이페이지 버튼 추가하면 삭제 예정 */}
+      <Button
+        label='마이페이지'
+        onClick={() => setIsOpen(true)}
+        baseButton
+        size='s'
+      />
+
+      {/* 반응형: 화면 크기에 따라 SideSheet / BottomSheet 전환 */}
+      {isMobile ? (
+        <BottomSheet isOpen={isOpen} onClose={() => setIsOpen(false)}>
+          {sheetContent}
+        </BottomSheet>
+      ) : (
+        <SideSheet isOpen={isOpen} onClose={() => setIsOpen(false)}>
+          {sheetContent}
+        </SideSheet>
+      )}
 
       {/* 로그아웃 모달 */}
       <LogoutModal


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#53 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### ✅ 마이페이지 반응형 구현 

- `isMobile` 을 활용하여 pc 사이즈 일 때는 sideSheet, 모바일 사이즈 일 때는 bottomSheet css 로 반응형 구현

### ✅ 바텀시트 수정

- 사이드 시트와 구조를 비슷하게 하기 위해서 footer 영역 추가했습니다. 

### ✅ 로고 컴포넌트 수정

- 로고 컴포넌트 사이즈 추가
```
  const sizeClasses = {
    xs: 'w-16 h-16', // 작은 사이즈
    s: 'w-20 h-20', // 추가 사이즈
    m: 'w-24 h-24', // 중간 사이즈 (기본값)
    l: 'w-32 h-32', // 큰 사이즈
  }
```

- 로고 클릭 시 홈으로 이동할 수 있는 navigate 기능 추가
```
  // 클릭 시 홈으로 이동
  const handleClick = () => {
    if (navigateOnClick) {
      navigate('/')
    }
  }
```

- 

### 스크린샷 (선택)

<img width="357" height="628" alt="image" src="https://github.com/user-attachments/assets/67e05364-0895-42b0-9199-19cc2889e592" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?